### PR TITLE
Fix example YAML in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ This component requires a `UART Bus <https://esphome.io/components/uart#uart>`_ 
     climate:
       - platform: haier
         id: haier_ac
-        protocol: hOn
+        protocol: hon
         name: Haier AC
         uart_id: ac_port
         wifi_signal: true

--- a/docs/esphome-docs/climate/haier.rst
+++ b/docs/esphome-docs/climate/haier.rst
@@ -61,7 +61,7 @@ This component requires a :ref:`uart` to be setup.
     climate:
       - platform: haier
         id: haier_ac
-        protocol: hOn
+        protocol: hon
         name: Haier AC
         uart_id: ac_port
         wifi_signal: true


### PR DESCRIPTION
The protocol value for `h0n` has to be [`hon`](https://github.com/paveldn/haier-esphome/blob/d6d58800b6cb1776f61d599b9004fc8ce7e017ec/components/haier/climate.py#L60). The example states this incorrectly causing a validation error. Should also be updated in the ESPHome docs I guess. 

