### PR TITLE
docs: add tip on swapping tx/rx pins

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -50,7 +50,7 @@ Troubleshooting
 
 **Troubleshooting Steps:**
 
-1. Check the Wiring: Ensure all connections are secure. Try using different pins for communication.
+1. Check the Wiring: Ensure all connections are secure. Try using different pins for communication. The internal board wiring might not reflect the diagrams. Try swapping the RX and TX assignments physically or via software in the esphome configuration.
 2. Test with Different Hardware: If possible, test with a different ESP module or AC unit to isolate the issue.
 3. Use a Simulator: If you're familiar with C++ and cmake, consider using a simulator to diagnose the issue. I have simulator applications for both the hOn and smartAir2 protocols:
 


### PR DESCRIPTION
First of all thanks for creating this project, it works quite well! 
Recently I've set up 2 ACs with this integration and couldn't get them to work initially because the AC's board internal wiring doesn't reflect the diagram (I think the TX and RX connections are swapped). 
The docs mention this but are not explicit about the options there are (physical and software changes) to solve the problem so I figured I could add them here to help others facing the same problem.