### PR TITLE
Add `ECO` preset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,7 @@ This component requires a `UART Bus <https://esphome.io/components/uart#uart>`_ 
         supported_presets:
         - AWAY
         - BOOST
+        - ECO
         - SLEEP
         on_alarm_start:
           then:
@@ -123,7 +124,7 @@ Configuration variables:
 - **beeper** (*Optional*, boolean): Can be used to disable beeping on commands from AC. Supported only by hOn protocol.
 - **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: ``'OFF'``, ``HEAT_COOL``, ``COOL``, ``HEAT``, ``DRY``, ``FAN_ONLY``.
 - **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: ``'OFF'``, ``VERTICAL``, ``HORIZONTAL``, ``BOTH``.
-- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
+- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``ECO``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
 - **on_alarm_start** (*Optional*, `Automation <https://esphome.io/guides/automations#automation>`_): (supported only by hOn) Automation to perform when AC activates a new alarm. See `on_alarm_start Trigger`_.
 - **on_alarm_end** (*Optional*, `Automation <https://esphome.io/guides/automations#automation>`_): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See `on_alarm_end Trigger`_.
 - **on_status_message** (*Optional*, `Automation <https://esphome.io/guides/automations#automation>`_): Automation to perform when status message received from AC. See `on_status_message Trigger`_.

--- a/components/haier/climate.py
+++ b/components/haier/climate.py
@@ -113,6 +113,7 @@ SUPPORTED_CLIMATE_PRESETS_SMARTAIR2_OPTIONS = {
 SUPPORTED_CLIMATE_PRESETS_HON_OPTIONS = {
     "AWAY": ClimatePreset.CLIMATE_PRESET_AWAY,
     "BOOST": ClimatePreset.CLIMATE_PRESET_BOOST,
+    "ECO": ClimatePreset.CLIMATE_PRESET_ECO,
     "SLEEP": ClimatePreset.CLIMATE_PRESET_SLEEP,
 }
 
@@ -235,7 +236,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_HVAC_ACTION, default=False): cv.boolean,
                     cv.Optional(
                         CONF_SUPPORTED_PRESETS,
-                        default=["BOOST", "SLEEP"],  # No AWAY by default
+                        default=["BOOST", "ECO", "SLEEP"],  # No AWAY by default
                     ): cv.ensure_list(
                         cv.enum(SUPPORTED_CLIMATE_PRESETS_HON_OPTIONS, upper=True)
                     ),

--- a/components/haier/hon_climate.cpp
+++ b/components/haier/hon_climate.cpp
@@ -622,6 +622,7 @@ haier_protocol::HaierMessage HonClimate::get_control_message() {
   hon_protocol::HaierPacketControl *out_data = (hon_protocol::HaierPacketControl *) control_out_buffer;
   control_out_buffer[4] = 0;  // This byte should be cleared before setting values
   bool has_hvac_settings = false;
+  bool quiet_mode = this->get_quiet_mode_state();
   if (this->current_hvac_settings_.valid) {
     has_hvac_settings = true;
     HvacSettings &climate_control = this->current_hvac_settings_;
@@ -719,29 +720,40 @@ haier_protocol::HaierMessage HonClimate::get_control_message() {
           out_data->fast_mode = 0;
           out_data->sleep_mode = 0;
           out_data->ten_degree = 0;
+          quiet_mode = false;
           break;
         case CLIMATE_PRESET_BOOST:
           // Boost is not supported in Fan only mode
           out_data->fast_mode = (this->mode != CLIMATE_MODE_FAN_ONLY) ? 1 : 0;
           out_data->sleep_mode = 0;
           out_data->ten_degree = 0;
+          quiet_mode = false;
           break;
         case CLIMATE_PRESET_AWAY:
           out_data->fast_mode = 0;
           out_data->sleep_mode = 0;
           // 10 degrees allowed only in heat mode
           out_data->ten_degree = (this->mode == CLIMATE_MODE_HEAT) ? 1 : 0;
+          quiet_mode = false;
+          break;
+        case CLIMATE_PRESET_ECO:
+          out_data->fast_mode = 0;
+          out_data->sleep_mode = 0;
+          out_data->ten_degree = 0;
+          quiet_mode = true;
           break;
         case CLIMATE_PRESET_SLEEP:
           out_data->fast_mode = 0;
           out_data->sleep_mode = 1;
           out_data->ten_degree = 0;
+          quiet_mode = false;
           break;
         default:
           ESP_LOGE("Control", "Unsupported preset");
           out_data->fast_mode = 0;
           out_data->sleep_mode = 0;
           out_data->ten_degree = 0;
+          quiet_mode = false;
           break;
       }
     }
@@ -765,7 +777,7 @@ haier_protocol::HaierMessage HonClimate::get_control_message() {
       // If AC is off or in fan only mode - no quiet mode allowed
       out_data->quiet_mode = 0;
     } else {
-      out_data->quiet_mode = this->get_quiet_mode_state() ? 1 : 0;
+      out_data->quiet_mode = quiet_mode ? 1 : 0;
     }
     // Clean quiet mode state pending flag
     this->quiet_mode_state_ = (SwitchState) ((uint8_t) this->quiet_mode_state_ & 0b01);
@@ -1139,6 +1151,8 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
       this->preset = CLIMATE_PRESET_SLEEP;
     } else if (packet.control.ten_degree != 0) {
       this->preset = CLIMATE_PRESET_AWAY;
+    } else if (packet.control.quiet_mode != 0) {
+      this->preset = CLIMATE_PRESET_ECO;
     } else {
       this->preset = CLIMATE_PRESET_NONE;
     }
@@ -1447,33 +1461,56 @@ void HonClimate::fill_control_messages_queue_() {
   {
     uint8_t fast_mode_buf[] = {0x00, 0xFF};
     uint8_t away_mode_buf[] = {0x00, 0xFF};
+    uint8_t sleep_mode_buf[] = {0x00, 0xFF};
+    bool quiet_mode = this->get_quiet_mode_state();
     if (!new_power) {
       // If AC is off - no presets allowed
       fast_mode_buf[1] = 0x00;
       away_mode_buf[1] = 0x00;
+      sleep_mode_buf[1] = 0x00;
+      quiet_mode = false;
     } else if (climate_control.preset.has_value()) {
       switch (climate_control.preset.value()) {
         case CLIMATE_PRESET_NONE:
           fast_mode_buf[1] = 0x00;
           away_mode_buf[1] = 0x00;
+          sleep_mode_buf[1] = 0x00;
+          quiet_mode = false;
           break;
         case CLIMATE_PRESET_BOOST:
           // Boost is not supported in Fan only mode
           fast_mode_buf[1] = (this->mode != CLIMATE_MODE_FAN_ONLY) ? 0x01 : 0x00;
           away_mode_buf[1] = 0x00;
+          sleep_mode_buf[1] = 0x00;
+          quiet_mode = false;
           break;
         case CLIMATE_PRESET_AWAY:
           fast_mode_buf[1] = 0x00;
           away_mode_buf[1] = (this->mode == CLIMATE_MODE_HEAT) ? 0x01 : 0x00;
+          sleep_mode_buf[1] = 0x00;
+          quiet_mode = false;
+          break;
+        case CLIMATE_PRESET_ECO:
+          fast_mode_buf[1] = 0x00;
+          away_mode_buf[1] = 0x00;
+          sleep_mode_buf[1] = 0x00;
+          quiet_mode = true;
+          break;
+        case CLIMATE_PRESET_SLEEP:
+          fast_mode_buf[1] = 0x00;
+          away_mode_buf[1] = 0x00;
+          sleep_mode_buf[1] = 0x01;
+          quiet_mode = false;
           break;
         default:
           ESP_LOGE("Control", "Unsupported preset");
+          quiet_mode = false;
           break;
       }
     }
     {
       // Quiet mode
-      if (new_power && (climate_mode != CLIMATE_MODE_FAN_ONLY) && this->get_quiet_mode_state()) {
+      if (new_power && (climate_mode != CLIMATE_MODE_FAN_ONLY) && quiet_mode) {
         quiet_mode_buf[1] = 0x01;
       } else {
         quiet_mode_buf[1] = 0x00;
@@ -1499,6 +1536,12 @@ void HonClimate::fill_control_messages_queue_() {
                                             (uint16_t) hon_protocol::SubcommandsControl::SET_SINGLE_PARAMETER +
                                                 (uint8_t) hon_protocol::DataParameters::TEN_DEGREE,
                                             away_mode_buf, 2);
+    }
+    if ((sleep_mode_buf[1] != 0xFF) && presets.count(climate::ClimatePreset::CLIMATE_PRESET_SLEEP)) {
+      this->control_messages_queue_.emplace(haier_protocol::FrameType::CONTROL,
+                                            (uint16_t) hon_protocol::SubcommandsControl::SET_SINGLE_PARAMETER +
+                                                (uint8_t) hon_protocol::DataParameters::SLEEP_MODE,
+                                            sleep_mode_buf, 2);
     }
   }
   // Target temperature

--- a/configs/climate/haier_hon.yaml
+++ b/configs/climate/haier_hon.yaml
@@ -25,6 +25,7 @@
       - BOTH
     supported_presets:          # Optional, can be used to disable some presets if your AC does not support it
       - BOOST
+      - ECO
       - SLEEP
     # Next two triggers calling Home Assistant services to notify user about alarms triggered by AC
     # this functionality is disabled by default. To enable it check "Allow the device to make Home Assistant service calls"

--- a/docs/esphome-docs/climate/haier.rst
+++ b/docs/esphome-docs/climate/haier.rst
@@ -85,6 +85,7 @@ This component requires a :ref:`UART bus <uart>` to be setup.
         supported_presets:
         - AWAY
         - BOOST
+        - ECO
         - SLEEP
         on_alarm_start:
           then:
@@ -123,7 +124,7 @@ Configuration variables:
 - **beeper** (*Optional*, boolean): Can be used to disable beeping on commands from AC. Supported only by hOn protocol.
 - **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: ``'OFF'``, ``HEAT_COOL``, ``COOL``, ``HEAT``, ``DRY``, ``FAN_ONLY``.
 - **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: ``'OFF'``, ``VERTICAL``, ``HORIZONTAL``, ``BOTH``.
-- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
+- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``ECO``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
 - **on_alarm_start** (*Optional*, :ref:`Automation <automation>`): (supported only by hOn) Automation to perform when AC activates a new alarm. See :ref:`haier-on_alarm_start`.
 - **on_alarm_end** (*Optional*, :ref:`Automation <automation>`): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See :ref:`haier-on_alarm_end`.
 - **on_status_message** (*Optional*, :ref:`Automation <automation>`): Automation to perform when status message received from AC. See :ref:`haier-on_status_message`.

--- a/docs/examples/climate_haier.rst
+++ b/docs/examples/climate_haier.rst
@@ -74,7 +74,7 @@ Configuration variables:
 - **beeper** (*Optional*, boolean): Can be used to disable beeping on commands from AC. Supported only by hOn protocol.
 - **supported_modes** (*Optional*, list): Can be used to disable some of AC modes. Possible values: ``'OFF'``, ``HEAT_COOL``, ``COOL``, ``HEAT``, ``DRY``, ``FAN_ONLY``.
 - **supported_swing_modes** (*Optional*, list): Can be used to disable some swing modes if your AC does not support it. Possible values: ``'OFF'``, ``VERTICAL``, ``HORIZONTAL``, ``BOTH``.
-- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
+- **supported_presets** (*Optional*, list): Can be used to disable some presets. Possible values for smartair2 are: ``AWAY``, ``BOOST``, ``COMFORT``. Possible values for hOn are: ``AWAY``, ``BOOST``, ``ECO``, ``SLEEP``. ``AWAY`` preset can be enabled only in ``HEAT`` mode, it is disabled by default.
 - **on_alarm_start** (*Optional*, :ref:`Automation <automation>`): (supported only by hOn) Automation to perform when AC activates a new alarm. See :ref:`haier-on_alarm_start`.
 - **on_alarm_end** (*Optional*, :ref:`Automation <automation>`): (supported only by hOn) Automation to perform when AC deactivates a new alarm. See :ref:`haier-on_alarm_end`.
 - **on_status_message** (*Optional*, :ref:`Automation <automation>`): Automation to perform when status message received from AC. See :ref:`haier-on_status_message`.

--- a/docs/examples/esphome_climate_example.yaml
+++ b/docs/examples/esphome_climate_example.yaml
@@ -26,6 +26,7 @@ climate:
     supported_presets:
     - AWAY
     - BOOST
+    - ECO
     - SLEEP
     on_alarm_start:
       then:

--- a/docs/examples/max-hon.yaml
+++ b/docs/examples/max-hon.yaml
@@ -40,6 +40,7 @@ climate:
       - BOTH
     supported_presets:
       - BOOST
+      - ECO
       - SLEEP
     on_alarm_start:
       then:

--- a/docs/hon_example.rst
+++ b/docs/hon_example.rst
@@ -68,6 +68,7 @@ Maximum configuration witch will use all possible options will look like this:
           - BOTH
         supported_presets:
           - BOOST
+          - ECO
           - SLEEP
         on_alarm_start:
           then:


### PR DESCRIPTION
This PR adds a new `ECO` preset to the `climate` entity (for hOn only), which enables the quiet mode.

I frequently use both quiet / boost modes, and it's much more convenient to control these modes from a single place and within a single climate card rather than using a separate switch for quiet mode. Additionally, boost and quiet modes are mutually exclusive, so this change seems logical.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/b73ee21b-4b20-403c-b571-411a81d7c5f7" />
