### PR TITLE
Don't abort cleaning cycle by auto-correcting display state

### DIFF
--- a/components/haier/hon_climate.cpp
+++ b/components/haier/hon_climate.cpp
@@ -937,9 +937,14 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
     should_publish = should_publish || (!old_fan_mode.has_value()) ||
                      (old_fan_mode.value_or(CLIMATE_FAN_ON) != this->fan_mode.value_or(CLIMATE_FAN_ON));
   }
+  // A cleaning cycle powers the AC on by itself and the AC lights the display while it runs
+  bool cleaning_active = (packet.control.steri_clean == 1) || (packet.control.self_cleaning_status == 1);
   // Display status
   // should be before "Climate mode" because it is changing this->mode
-  if (packet.control.ac_power != 0) {
+  // Skipped while cleaning: the AC lights the display on its own and forcing it back off sends a
+  // control packet that clears the cleaning bits. The AC then leaves the cycle, this handler sees
+  // NO_CLEANING and powers the AC off - the whole cycle dies about a second after it started.
+  if ((packet.control.ac_power != 0) && !cleaning_active) {
     // if AC is off display status always ON so process it only when AC is on
     bool disp_status = packet.control.display_status != 0;
     if (disp_status != this->get_display_state()) {
@@ -1301,6 +1306,16 @@ void HonClimate::clear_control_messages_queue_() {
 
 bool HonClimate::prepare_pending_action() {
   auto &action_request = this->action_request_.value();  // NOLINT(bugprone-unchecked-optional-access)
+  if ((action_request.action == ActionRequest::START_SELF_CLEAN) ||
+      (action_request.action == ActionRequest::START_STERI_CLEAN)) {
+    // Drop anything control-shaped that is still pending: a control packet arriving right after the
+    // cleaning command overwrites the cleaning bits and the AC drops out of the cycle. Nothing is
+    // lost by dropping it - a cleaning cycle overrides mode, setpoint and louver positions anyway.
+    this->force_send_control_ = false;
+    this->clear_control_messages_queue_();
+    if (this->current_hvac_settings_.valid)
+      this->current_hvac_settings_.reset();
+  }
   switch (action_request.action) {
     case ActionRequest::START_SELF_CLEAN:
       if (this->control_method_ == HonControlMethod::SET_GROUP_PARAMETERS) {


### PR DESCRIPTION
Starting a cleaning cycle with the display switch off kills it after ~1.5 s.

Cleaning sets `ac_power = 1`, but the AC powers on with its display lit. The display block
(`hon_climate.cpp:942`) sees the mismatch while `this->mode` is still `OFF`, treats it as
"turned on from remote" and sets `force_send_control_`. That control packet clears the cleaning
bits, and the next status makes the handler send `TURN_POWER_OFF` (line 981).

Fix: skip display auto-correction while cleaning is active, and drop pending control state when a
cleaning action is prepared (same effect from a queued packet). An explicit user command during a
cycle still cancels it, as before.

Tested on AS25S2SF1FA-BH (`U-AC`, `E++2.18`, `SET_GROUP_PARAMETERS`): steri-cleaning with the
display off failed before, runs the full cycle after.